### PR TITLE
Add support for a timezone option

### DIFF
--- a/42fdr.conf.example
+++ b/42fdr.conf.example
@@ -5,9 +5,12 @@ OutPath  = .
 
 [DREFS]
 sim/cockpit2/gauges/indicators/airspeed_kts_pilot = {Speed}, 1.0, IAS
-sim/cockpit2/gauges/indicators/altitude_ft_pilot = {ALTMSL}, 1.0, Alt
-sim/cockpit2/gauges/actuators/barometer_setting_in_hg_pilot = 29.92, 1.0
-
+sim/cockpit2/gauges/indicators/altitude_ft_pilot = {ALTMSL}, 1.0, Altimeter
+sim/cockpit2/gauges/actuators/barometer_setting_in_hg_pilot = 29.92, 1.0, Barometer
+sim/cockpit2/gauges/indicators/compass_heading_deg_mag = {HEADING}, 1.0, Compass
+sim/cockpit2/gauges/indicators/heading_vacuum_deg_mag_pilot = {HEADING}, 1.0, Vacuum Heading
+sim/cockpit2/gauges/indicators/pitch_vacuum_deg_pilot = {PITCH}, 1.0, Vacuum Pitch
+sim/cockpit2/gauges/indicators/roll_vacuum_deg_pilot = {ROLL}, 1.0, Vacuum Roll
 
 [Aircraft/PIPERS_1150/Piper_PA-28-161/Piper_PA-28-161(Garmin)/piper warrior.acf]
 Tails = N222ND, N238ND, N239ND, N263ND, N267ND, N276ND, N291MK

--- a/42fdr.conf.example
+++ b/42fdr.conf.example
@@ -1,5 +1,5 @@
 [Defaults]
-Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf
+Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf
 OutPath  = .
 
 

--- a/42fdr.py
+++ b/42fdr.py
@@ -19,7 +19,7 @@ class FileType(Enum):
 class Config():
     outPath:str = '.'
     timezone:int = 0
-    aircraft:str = 'Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf'
+    aircraft:str = 'Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf'
 
     file:MutableMapping = None
     drefSources:Dict[str, str] = {}

--- a/42fdr.py
+++ b/42fdr.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-import argparse, configparser, csv, os, re, sys
-import math
-import xml.etree.ElementTree as ET
+import argparse, configparser, csv, os, re, sys, xml.etree.ElementTree as ET
+import math  # Used when evaluating user DREF value expressions
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
@@ -19,21 +18,30 @@ class FileType(Enum):
 
 class Config():
     outPath:str = '.'
+    timezone:int = 0
     aircraft:str = 'Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf'
-    config:MutableMapping = None
+
+    file:MutableMapping = None
     drefSources:Dict[str, str] = {}
     drefDefines:List[str] = []
 
     def __init__(self, cliArgs:argparse.Namespace):
         configFile = self.findConfigFile(cliArgs.config)
-        self.config = configparser.RawConfigParser()
-        self.config.read(configFile)
+        self.file = configparser.RawConfigParser()
+        self.file.read(configFile)
 
-        defaults = self.config['Defaults'] if 'Defaults' in self.config else {}
+        defaults = self.file['Defaults'] if 'Defaults' in self.file else {}
+
         if cliArgs.aircraft:
             self.aircraft = cliArgs.aircraft
         elif 'aircraft' in defaults:
             self.aircraft = defaults['aircraft']
+
+        if cliArgs.timezone:
+            self.timezone = secondsFromString(cliArgs.timezone)
+        elif 'timezone' in defaults:
+            self.timezone = secondsFromString(defaults['timezone'])
+
         if cliArgs.outputFolder:
             self.outPath = cliArgs.outputFolder
         elif 'outpath' in defaults:
@@ -41,8 +49,8 @@ class Config():
 
 
         self.addDref('sim/cockpit2/gauges/indicators/ground_speed_kt', '{Speed}', '1.0', 'GndSpd')
-        if 'DREFS' in self.config.sections():
-            drefs = self.config['DREFS']
+        if 'DREFS' in self.file.sections():
+            drefs = self.file['DREFS']
             for dref in drefs:
                 self.addDref(dref, *[x.strip() for x in drefs[dref].rsplit(',', 3)])
 
@@ -53,19 +61,19 @@ class Config():
             self.drefDefines.append(f'{instrument}\t{scale}\t\t// source: {value}')
 
     def acftByTail(self, tailNumber:str):
-        for section in self.config.sections():
+        for section in self.file.sections():
             if section.lower().startswith('aircraft/'):
-                aircraft = self.config[section]
+                aircraft = self.file[section]
                 if tailNumber in [tail.strip() for tail in aircraft['Tails'].split(',')]:
                     return section
 
     def tail(self, tailNumber:str):
-        for section in self.config.sections():
+        for section in self.file.sections():
             if section.lower() == tailNumber.lower():
-                tailSection = self.config[section]
+                tailSection = self.file[section]
 
                 tailConfig = {}
-                for key in self.config[section]:
+                for key in self.file[section]:
                     tailConfig[key] = numberOrString(tailSection[key])
 
                 if 'headingtrim' not in tailConfig:
@@ -156,6 +164,7 @@ def main(argv:List[str]):
     parser = argparse.ArgumentParser(description='Convert ForeFlight compatible track files into X-Plane compatible FDR files')
     parser.add_argument('-a', '--aircraft', default=None, help='Path to default X-Plane aircraft')
     parser.add_argument('-c', '--config', default=None, help='Path to 42fdr config file')
+    parser.add_argument('-t', '--timezone', default=None, help='An offset to add to all times processed.  +/-hh:mm[:ss] or +/-<decimal hours>')
     parser.add_argument('-o', '--outputFolder', default=None, help='Path to write X-Plane compatible FDR v4 output file')
     parser.add_argument('trackfile', default=None, nargs='+', help='Path to one or more ForeFlight compatible track files (CSV)')
     args = parser.parse_args()
@@ -229,9 +238,9 @@ def parseCsvFile(config:Config, trackFile:TextIO) -> FdrFlight:
         elif colName == 'End Longitude':
             flightMeta.EndLongitude = float(colValue)
         elif colName == 'Start Time':
-            flightMeta.StartTime = datetime.fromtimestamp(float(colValue) / 1000)
+            flightMeta.StartTime = datetime.fromtimestamp(float(colValue) / 1000 + config.timezone)
         elif colName == 'End Time':
-            flightMeta.EndTime = datetime.fromtimestamp(float(colValue) / 1000)
+            flightMeta.EndTime = datetime.fromtimestamp(float(colValue) / 1000 + config.timezone)
         elif colName == 'Total Duration':
             flightMeta.TotalDuration = timedelta(seconds=float(colValue))
         elif colName == 'Total Distance':
@@ -276,7 +285,7 @@ def parseCsvFile(config:Config, trackFile:TextIO) -> FdrFlight:
         fdrPoint = FdrTrackPoint()
         
         trackData = dict(zip(trackCols, trackVals))
-        fdrPoint.TIME = datetime.fromtimestamp(float(trackData['Timestamp']));
+        fdrPoint.TIME = datetime.fromtimestamp(float(trackData['Timestamp']) + config.timezone)
         fdrPoint.LAT = float(trackData['Latitude'])
         fdrPoint.LONG = float(trackData['Longitude'])
         fdrPoint.ALTMSL = float(trackData['Altitude'])
@@ -390,8 +399,36 @@ COMM,                      Longitude,            Latitude,              AltMSL, 
     return names +'\n'
 
 
+def getOutpath(config:Config, inPath:str, fdrData:FdrFlight):
+    filename = os.path.basename(inPath)
+    outPath = config.outPath or '.'
+    return Path(os.path.join(outPath, filename)).with_suffix('.fdr')
+
+
+def secondsFromString(timezone:str):
+    seconds = 0
+
+    timezone = numberOrString(timezone)
+    if isinstance(timezone, (float, int)):
+        seconds = timezone * 3600
+    elif isinstance(timezone, str):
+        indexAfterSign = int(timezone[0] in ['+','-'])
+        zone = timezone[indexAfterSign:].split(':')
+
+        seconds = float(zone.pop())
+        seconds += float(zone.pop()) * 60
+        if len(zone):
+            seconds += float(zone.pop()) * 3600
+        else:
+            seconds *= 60
+
+        seconds *= -1 if timezone[0] == '-' else 1
+
+    return seconds
+
+
 def numberOrString(numeric:str):
-    if re.sub('^-', '', re.sub('\\.', '', numeric)).isnumeric():
+    if re.sub('^[+-]', '', re.sub('\\.', '', numeric)).isnumeric():
         return float(numeric)
     else:
         return numeric
@@ -406,12 +443,6 @@ def plusMinus180(degrees:float):
         return degrees + 360
     else:
         return degrees
-
-
-def getOutpath(config:Config, inPath:str, fdrData:FdrFlight):
-    filename = os.path.basename(inPath)
-    outPath = config.outPath or '.'
-    return Path(os.path.join(outPath, filename)).with_suffix('.fdr')
 
 
 def toMDY(time:Union[datetime,int,str]):

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ rollTrim    = 0.0
 
 
 #### DREF Field Reference:
-**CSV track data contains the raw values from the input file.
+**CSV Track data contains the raw values from the input file.
 After converting the timestamp to a normal date and time, and
 calibrating the attitude, the processed data is made available
-as FDR track data*
+as FDR Track data*
 
-***Speed is not available in FDR Flight data as it is
-technically a DREF value and not part of the core FDR file*
+***Speed is not available in FDR Track data as it is technically
+a DREF value and not part of the core FDR file*
 | Track (CSV) | Track (FDR) | Flight (meta)            |
 |-------------|-------------|--------------------------|
 | {Timestamp} | {TIME}      | {Pilot}                  |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Just put 42fdr.py somewhere on your computer.
 | Options | Description |
 |---------|-------------|
 | `-c`    | Specify a config file.  A config file can be used to set the options below instead of on the command-line.  A config file can also define custom DREFs, automatically lookup an X-Plane aircraft by tail number, and load tail specific attitude calibrations.
-| `-a`    | Choose an X-Plane aircraft.  X-Plane requires the FDR file to specify an aircraft model for the flight and this is not provided by the ForeFlight track file.  `Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf` is used by default unless overriden with a config file or command line option.
+| `-a`    | Choose an X-Plane aircraft.  X-Plane requires the FDR file to specify an aircraft model for the flight and this is not provided by the ForeFlight track file.  `Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf` is used by default unless overriden with a config file or command line option.
 | `-t`    | Adjust all times by this (positive or negative) amount.  Can be expressed as a decimal number of hours `(e.g. 3.5)` or in the format hh:mm[:ss] `(e.g. -5:00)`
 | `-o`    | Choose a different output path.
 
@@ -62,7 +62,7 @@ A field reference is provided at the end of this section, after the example conf
 
 ### [<Aircraft/*>]
 `<Aircraft/*>` sections allows you to map specific tail numbers to X-Plane aircraft models.
-The section name should be the path to the .acf model file, beginning with the Aircraft folder `(e.g. [Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf])`
+The section name should be the path to the .acf model file, beginning with the Aircraft folder `(e.g. [Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf])`
 
 A single key is supported, `Tails`, which can be used to list all tail numbers which should cause this aircraft to be used in the output file `(e.g. N1234X, N5678Y)`.
 
@@ -77,7 +77,7 @@ These sections supports three keys (`headingTrim`, `pitchTrim`, `rollTrim`) and 
 #### 42fdr.conf example:
 ```
 [Defaults]
-Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf
+Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf
 OutPath  = .
 
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ Just put 42fdr.py somewhere on your computer.
 
 
 ## Usage
-`[python3] 42fdr.py [-c configFile ] [-a Aircraft] [-o outputFolder] trackFile1 [trackFile2, trackFile3, ...]`
+`[python3] 42fdr.py [-c configFile] [-a aircraft] [-t timezone] [-o outputFolder] trackFile1 [trackFile2, trackFile3, ...]`
 
-You should be able to run 42fdr without explicitly invoking the python interpreter.
-It will convert one or more files, rename it with the `.fdr` extension, and save the output to the current working directory.
-Choose a different output path with the `-o` parameter.
+**You should be able to run 42fdr without explicitly invoking the python interpreter.*
 
-X-Plane requires the FDR file to specify an aircraft model for the flight and this is not provided by the ForeFlight track file.
-`Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf` will be used by default. 
-Choose a different aircraft with the `-a` parameter.
+42FDR will convert one or more files, rename it with the `.fdr` extension, and save the output to the current working directory.
 
-Specify a config file with the `-c` parameter. 
+| Options | Description |
+|---------|-------------|
+| `-c`    | Specify a config file.  A config file can be used to set the options below instead of on the command-line.  A config file can also define custom DREFs, automatically lookup an X-Plane aircraft by tail number, and load tail specific attitude calibrations.
+| `-a`    | Choose an X-Plane aircraft.  X-Plane requires the FDR file to specify an aircraft model for the flight and this is not provided by the ForeFlight track file.  `Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf` is used by default unless overriden with a config file or command line option.
+| `-t`    | Adjust all times by this (positive or negative) amount.  Can be expressed as a decimal number of hours `(e.g. 3.5)` or in the format hh:mm[:ss] `(e.g. -5:00)`
+| `-o`    | Choose a different output path.
+
 
 
 ## Using a config file
@@ -37,7 +39,7 @@ One `[Defaults]` section, one `[DREFS]` section, and as many `[<Aircraft/*>]` an
 
 
 ### [Defaults]
-The `Defaults` section supports two keys, `aircraft` and `outpath`, which provide defaults for when their respective command-line arguments are not provided.
+The `Defaults` section supports three keys, `aircraft`, `timezone`, and `outpath`, which provide defaults for when their respective command-line arguments are not provided.
 
 
 ### [DREFS]
@@ -98,22 +100,22 @@ rollTrim    = 0.0
 
 #### DREF Field Reference:
 **CSV Track data contains the raw values from the input file.
-After converting the timestamp to a normal date and time, and
-calibrating the attitude, the processed data is made available
-as FDR Track data*
+After converting the timestamp to a normal date and time,
+adjusting for timezone, and calibrating the attitude,
+the processed data is made available as FDR Track data*
 
-***Speed is not available in FDR Track data as it is technically
+***GndSpd is not available in FDR Track data as it is technically
 a DREF value and not part of the core FDR file*
-| Track (CSV) | Track (FDR) | Flight (meta)            |
+| Track (FDR) | Track (CSV) | Flight (meta)            |
 |-------------|-------------|--------------------------|
-| {Timestamp} | {TIME}      | {Pilot}                  |
-| {Latitude}  | {LAT}       | {TailNumber}             |
-| {Longitude} | {LONG}      | {DerivedOrigin}          |
-| {Altitude}  | {ALTMSL}    | {StartLatitude}          |
-| {Course}    | {HEADING}   | {StartLongitude}         |
-| {Pitch}     | {PITCH}     | {DerivedDestination}     |
-| {Bank}      | {ROLL}      | {EndLatitude}            |
-| {Speed}     |             | {EndLongitude}           |
+| {TIME}      | {Timestamp} | {Pilot}                  |
+| {LAT}       | {Latitude}  | {TailNumber}             |
+| {LONG}      | {Longitude} | {DerivedOrigin}          |
+| {ALTMSL}    | {Altitude}  | {StartLatitude}          |
+| {HEADING}   | {Course}    | {StartLongitude}         |
+| {PITCH}     | {Pitch}     | {DerivedDestination}     |
+| {ROLL}      | {Bank}      | {EndLatitude}            |
+|             | {Speed}     | {EndLongitude}           |
 |             |             | {StartTime}              |
 |             |             | {EndTime}                |
 |             |             | {TotalDuration}          |


### PR DESCRIPTION
- Add support for a timezone option
  - Can be set in the config file and on the command line
  - Value is a positive or negative offset in the form hh:mm[:ss], or in decimal hours.
  - Offset is added to all processed times

- Update README.md
  - Add documentation for new timezone options
  - Reformat usage options into table
  - Minor edits for readability

- Change default aircraft
  - from: Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP_G1000.acf
  - to  : Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf