### PR TITLE
DREFs should specifiable at any level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 42fdr.conf
 42fdr.ini
 
+# vscode
+.vscode
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/42fdr.conf.example
+++ b/42fdr.conf.example
@@ -1,23 +1,23 @@
 [Defaults]
 Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf
-Timezone = 5
+Timezone = 4
 OutPath  = .
 
-DREF sim/cockpit2/gauges/indicators/airspeed_kts_pilot = {Speed}, 1.0, IAS
-DREF sim/cockpit2/gauges/indicators/altitude_ft_pilot = {ALTMSL}, 1.0, Altimeter
+DREF sim/cockpit2/gauges/indicators/airspeed_kts_pilot = round({Speed}, 4), 1.0, IAS
+DREF sim/cockpit2/gauges/indicators/altitude_ft_pilot = round({ALTMSL}, 4), 1.0, Altimeter
+DREF sim/cockpit2/gauges/indicators/compass_heading_deg_mag = round({HEADING}, 3), 1.0, Compass
 
 
-[Aircraft/PIPERS_1150/Piper_PA-28-161/Piper_PA-28-161(Garmin)/piper warrior.acf]
-Tails = N222ND, N238ND, N239ND, N263ND, N267ND, N276ND, N291MK
+[Aircraft/AeroSphere Piper Warrior/PiperWarrior/PiperWarrior.acf]
+Tails = N123ND, N321ND
 
+DREF sim/cockpit2/gauges/indicators/heading_vacuum_deg_mag_pilot = round({HEADING}, 3), 1.0, Vacuum Heading
+DREF sim/cockpit2/gauges/indicators/pitch_vacuum_deg_pilot = round({PITCH}, 3), 1.0, Vacuum Pitch
+DREF sim/cockpit2/gauges/indicators/roll_vacuum_deg_pilot = round({ROLL}, 3), 1.0, Vacuum Roll
 DREF sim/cockpit2/gauges/actuators/barometer_setting_in_hg_pilot = 29.92, 1.0, Barometer
-DREF sim/cockpit2/gauges/indicators/compass_heading_deg_mag = {HEADING}, 1.0, Compass
-DREF sim/cockpit2/gauges/indicators/heading_vacuum_deg_mag_pilot = {HEADING}, 1.0, Vacuum Heading
-DREF sim/cockpit2/gauges/indicators/pitch_vacuum_deg_pilot = {PITCH}, 1.0, Vacuum Pitch
-DREF sim/cockpit2/gauges/indicators/roll_vacuum_deg_pilot = {ROLL}, 1.0, Vacuum Roll
 
 
-[N263ND]
+[N123ND]
 headingTrim = 0.0
 pitchTrim   = 0.0
 rollTrim    = 0.0

--- a/42fdr.conf.example
+++ b/42fdr.conf.example
@@ -3,18 +3,18 @@ Aircraft = Aircraft/Laminar Research/Cessna 172 SP/Cessna_172SP.acf
 Timezone = 5
 OutPath  = .
 
+DREF sim/cockpit2/gauges/indicators/airspeed_kts_pilot = {Speed}, 1.0, IAS
+DREF sim/cockpit2/gauges/indicators/altitude_ft_pilot = {ALTMSL}, 1.0, Altimeter
 
-[DREFS]
-sim/cockpit2/gauges/indicators/airspeed_kts_pilot = {Speed}, 1.0, IAS
-sim/cockpit2/gauges/indicators/altitude_ft_pilot = {ALTMSL}, 1.0, Altimeter
-sim/cockpit2/gauges/actuators/barometer_setting_in_hg_pilot = 29.92, 1.0, Barometer
-sim/cockpit2/gauges/indicators/compass_heading_deg_mag = {HEADING}, 1.0, Compass
-sim/cockpit2/gauges/indicators/heading_vacuum_deg_mag_pilot = {HEADING}, 1.0, Vacuum Heading
-sim/cockpit2/gauges/indicators/pitch_vacuum_deg_pilot = {PITCH}, 1.0, Vacuum Pitch
-sim/cockpit2/gauges/indicators/roll_vacuum_deg_pilot = {ROLL}, 1.0, Vacuum Roll
 
 [Aircraft/PIPERS_1150/Piper_PA-28-161/Piper_PA-28-161(Garmin)/piper warrior.acf]
 Tails = N222ND, N238ND, N239ND, N263ND, N267ND, N276ND, N291MK
+
+DREF sim/cockpit2/gauges/actuators/barometer_setting_in_hg_pilot = 29.92, 1.0, Barometer
+DREF sim/cockpit2/gauges/indicators/compass_heading_deg_mag = {HEADING}, 1.0, Compass
+DREF sim/cockpit2/gauges/indicators/heading_vacuum_deg_mag_pilot = {HEADING}, 1.0, Vacuum Heading
+DREF sim/cockpit2/gauges/indicators/pitch_vacuum_deg_pilot = {PITCH}, 1.0, Vacuum Pitch
+DREF sim/cockpit2/gauges/indicators/roll_vacuum_deg_pilot = {ROLL}, 1.0, Vacuum Roll
 
 
 [N263ND]

--- a/42fdr.py
+++ b/42fdr.py
@@ -240,17 +240,18 @@ def parseCsvFile(config:Config, trackFile:TextIO) -> FdrFlight:
         elif colName == 'Derived Origin':
             flightMeta.DerivedOrigin = colValue
         elif colName == 'Start Latitude':
-            flightMeta.StartLatitude = float(colValue)
+            flightMeta.StartLatitude = round(float(colValue), 7)
         elif colName == 'Start Longitude':
-            flightMeta.StartLongitude = float(colValue)
+            flightMeta.StartLongitude = round(float(colValue), 7)
         elif colName == 'Derived Destination':
             flightMeta.DerivedDestination = colValue
         elif colName == 'End Latitude':
-            flightMeta.EndLatitude = float(colValue)
+            flightMeta.EndLatitude = round(float(colValue), 7)
         elif colName == 'End Longitude':
-            flightMeta.EndLongitude = float(colValue)
+            flightMeta.EndLongitude = round(float(colValue), 7)
         elif colName == 'Start Time':
             flightMeta.StartTime = datetime.fromtimestamp(float(colValue) / 1000 + config.timezone)
+            fdrFlight.DATE = flightMeta.StartTime.date()
         elif colName == 'End Time':
             flightMeta.EndTime = datetime.fromtimestamp(float(colValue) / 1000 + config.timezone)
         elif colName == 'Total Duration':
@@ -339,10 +340,10 @@ def parseGpxFile(config:Config, trackFile:TextIO) -> FdrFlight:
 def flightSummary(flightMeta:FlightMeta) -> str:
     hoursMinutes = str(flightMeta.TotalDuration).split(':')[:2]
 
-    return f'''{flightMeta.TailNumber} - {toMDY(flightMeta.StartTime)} {flightMeta.TotalDistance} miles{(' by '+ flightMeta.Pilot) if flightMeta.Pilot else ''} ({hoursMinutes[0]} hours and {hoursMinutes[1]} minutes)
+    return f'''{flightMeta.TailNumber} - {toYMD(flightMeta.StartTime)} {flightMeta.TotalDistance:.2f} miles{(' by '+ flightMeta.Pilot) if flightMeta.Pilot else ''} ({hoursMinutes[0]} hours and {hoursMinutes[1]} minutes)
 
-    From: {toHMS(flightMeta.StartTime)} {flightMeta.DerivedOrigin} ({flightMeta.StartLatitude}, {flightMeta.StartLongitude})
-      To: {toHMS(flightMeta.EndTime)} {flightMeta.DerivedDestination} ({flightMeta.EndLatitude}, {flightMeta.EndLongitude})
+    From: {toHM(flightMeta.StartTime)}Z {flightMeta.DerivedOrigin} ({flightMeta.StartLatitude}, {flightMeta.StartLongitude})
+      To: {toHM(flightMeta.EndTime)}Z {flightMeta.DerivedDestination} ({flightMeta.EndLatitude}, {flightMeta.EndLongitude})
  Planned: {flightMeta.RouteWaypoints}
 GPS/AHRS: {flightMeta.GPSSource}
   Client: {flightMeta.DeviceModelDetailed} iOS v{flightMeta.iOSVersion}'''
@@ -467,12 +468,20 @@ def toMDY(time:Union[datetime,int,str]):
     return time.strftime('%m/%d/%Y')
 
 
-def toHMS(time:Union[datetime,int,str]):
+def toYMD(time:Union[datetime,int,str]):
     if isinstance(time, str):
         time = int(time)
     if isinstance(time, int):
         time = datetime.fromtimestamp(time / 1000)
-    return time.strftime('%H:%M:%S')
+    return time.strftime('%Y/%m/%d')
+
+
+def toHM(time:Union[datetime,int,str]):
+    if isinstance(time, str):
+        time = int(time)
+    if isinstance(time, int):
+        time = datetime.fromtimestamp(time / 1000)
+    return time.strftime('%H:%M')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
[DREFs should specifiable at any level #9](https://github.com/MadReasonable/42fdr/issues/9)
- [Defaults] DREFs should be added to all FDR files
- [\<Aircraft/*>] DREFs should be added to all flights using that specific X-Plane aircraft model
- [\<Tail>] DREFs should be added to all flights using that specific tail number.

Additional changes:
- A bug fix for DREF expressions that contained commas (e.g. when using the `round(number, ndigits)` function
- Tolerance for backslashes instead of forward slashes in Aircraft and DREF paths
- Round some values in the output FDR file
  - Precision is still maintained at a ridiculous sub-millimeter, levels.  It was even crazier before.