### PR TITLE
Fix config file example

### DIFF
--- a/42fdr.conf.full
+++ b/42fdr.conf.full
@@ -33,7 +33,7 @@ DREF sim/cockpit2/gauges/indicators/airspeed_kts_pilot = round(({Speed} * 1.03) 
 
 
 ; Legacy tail sections are still supported:
-[N123ND]
+[N321ND]
 headingTrim = 12.0
 
 


### PR DESCRIPTION
Fix tail number for legacy [Tail#] section in new 42fdr.config.full example file.